### PR TITLE
Issue habilitado, strings contains, employee back button

### DIFF
--- a/pages/api/getPageEmpleados.ts
+++ b/pages/api/getPageEmpleados.ts
@@ -24,7 +24,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             direccion || null,
             puesto || null,
             pc_cat || null,
-            null,
+            habilitado || null
         );
 
         res.status(200).json([count, employees]);

--- a/pages/api/services/getPageEmpleados.ts
+++ b/pages/api/services/getPageEmpleados.ts
@@ -20,7 +20,7 @@ export default async function getPageEmpleados(
     const createAND = (name: string, filter: FilterData | null, isString: boolean = true) => {
         if (!filter) return "";
         return isString
-            ? `AND LOWER (${name}) LIKE LOWER('${filter.value}%') `
+            ? `AND LOWER (${name}) LIKE LOWER('%${filter.value}%') `
             : `AND ${name} ${filter.condition} ${filter.value} `;
     };
     try {

--- a/pages/employee/index.tsx
+++ b/pages/employee/index.tsx
@@ -7,6 +7,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import Paper from "@mui/material/Paper";
 import PictureAsPdf from "@mui/icons-material/PictureAsPdf";
+import ArrowBack from "@mui/icons-material/ArrowBack";
 import Skeleton from "@mui/material/Skeleton";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
@@ -39,10 +40,11 @@ import deepClone from "@/utils/deepClone";
 import { GetTrayectoriaRequestBody } from "../api/getTablaTrayectoria";
 import { useRouter } from "next/router";
 import Navbar from "@/components/Navbar";
-import { ContainedButton } from "@/components/themed/ThemedButtons";
+import { ContainedButton, TextButton } from "@/components/themed/ThemedButtons";
 import PdfEmployee from "@/utils/pdf/PdfEmployee";
 import { BlobProvider } from "@react-pdf/renderer";
 import { saveAs } from "file-saver";
+import Link from "next/link";
 
 type AllData = {
     dataEmpleado: TableEmpleado | null;
@@ -404,13 +406,13 @@ const EmployeePage: React.FC = (): JSX.Element => {
             </Head>
             {/* Navigation Bar */}
             <Navbar />
-            {/* Emplyoee sheet */}
+            {/* Employee sheet */}
             <Box>
                 <Container>
                     <Grid container gap={1} justifyContent="center" paddingBottom={8}>
                         {/* Left card */}
                         <Grid item xs={12} md={8}>
-                            <Paper variant="outlined" sx={{ padding: "1.5rem", height: "100%" }}>
+                            <Paper variant="outlined" sx={{ padding: "1.5rem", paddingTop: "1rem", height: "100%" }}>
                                 {/* Top section */}
                                 <EditSection
                                     index={0}
@@ -421,7 +423,14 @@ const EmployeePage: React.FC = (): JSX.Element => {
                                     disabled={dataEmpleado === null}
                                     disableSave={isUpdatingData}
                                 >
-                                    <Stack gap={3} mb={3}>
+                                    <Stack gap={2} mb={3}>
+                                        <Stack direction="row">
+                                            <Link href="/">
+                                                <TextButton variant="text" startIcon={<ArrowBack />}>
+                                                    Volver
+                                                </TextButton>
+                                            </Link>
+                                        </Stack>
                                         <Stack direction="row" gap={2} alignItems="center">
                                             {/* Avatar */}
                                             <>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ export default function Home() {
     // The state of the filters.
     type FilterType = {
         name: string;
-        isNumeric: boolean;
+        type: "string" | "number" | "boolean";
         isActive: boolean;
     };
     type FilterDataState = {
@@ -50,13 +50,13 @@ export default function Home() {
         }
     };
     const [filterData, dispatchFilterData] = useReducer<Reducer<FilterDataState, FilterDataAction>>(filterDataReducer, {
-        antiguedad: { name: "Antigüedad", isNumeric: true, isActive: false },
-        universidad: { name: "Universidad", isNumeric: false, isActive: false },
-        area_manager: { name: "Jefe", isNumeric: false, isActive: false },
-        direccion: { name: "Dirección", isNumeric: false, isActive: false },
-        puesto: { name: "Puesto", isNumeric: false, isActive: false },
-        pc_cat: { name: "PC - CAT", isNumeric: false, isActive: false },
-        habilitado: { name: "Habilitado", isNumeric: false, isActive: false },
+        antiguedad: { name: "Antigüedad", type: "number", isActive: false },
+        universidad: { name: "Universidad", type: "string", isActive: false },
+        area_manager: { name: "Jefe", type: "string", isActive: false },
+        direccion: { name: "Dirección", type: "string", isActive: false },
+        puesto: { name: "Puesto", type: "string", isActive: false },
+        pc_cat: { name: "PC - CAT", type: "string", isActive: false },
+        habilitado: { name: "Habilitado", type: "boolean", isActive: false },
     });
     // The selected filters
     type FiltersAction = { key: string; type: "add" | "remove"; data: FilterData };
@@ -141,6 +141,7 @@ export default function Home() {
     // Resets the pagination model each time the filters change.
     // Allows the list of employees to be updated.
     useEffect(() => {
+        console.log(filters);
         setPaginationModel({
             page: 0,
             pageSize: pageSize,
@@ -277,7 +278,7 @@ export default function Home() {
                                                     data: { condition: condition, value: value },
                                                 });
                                             }}
-                                            isNumeric={type.isNumeric}
+                                            type={type.type}
                                             key={name}
                                         ></FilterChip>
                                     );


### PR DESCRIPTION
Fixes the following bugs:
- The filter 'habilitado' was not working correctly.
- When filtering a string value, it didn't count as a match even if the filtered value was found inside the string. (ex. 'apellido' inside 'nombre apellido')
- The /employee page didn't have a return button.